### PR TITLE
workflows: clean up package publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,13 @@ jobs:
 
       - name: Add the GitHub NuGet registry as a package source
         run: |
-          dotnet nuget add source --username OWNER \
-          --password ${{ secrets.PACKAGE_TOKEN }} \
-          --name github \
-          "https://nuget.pkg.github.com/inspirational-impala-inc/index.json"
+          dotnet nuget add source --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text \
+            --name github \
+            "https://nuget.pkg.github.com/inspirational-impala-inc/index.json"
 
       - name: Publish the package
         run: |
-          dotnet nuget push 'bin/Release/*.nupkg' --source \
-            'https://nuget.pkg.github.com/inspirational-impala-inc/index.json' \
-             --api-key ${{ secrets.PACKAGE_TOKEN }}
+          dotnet nuget push 'bin/Release/*.nupkg' --source "github" \
+             --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ The scopes used for the personal access token in the `publish.yml` workflow are:
 
 - `write: packages`
 - `read: packages`
+
+# Publishing a new package version
+
+1. Create a new branch.
+2. Bump the version in the `dotnet-package.csproj` file.
+3. Push the branch to the server.
+4. Run the `Publish Package` workflow.

--- a/dotnet-package.csproj
+++ b/dotnet-package.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package metadata -->
     <PackageId>dotnet-package</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.3</Version>
     <Authors>Lessley Dennington</Authors>
     <Company>GitHub</Company>
     <PackageDescription>


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/publish.yml` and `README.md` files to improve the package publishing process and update the package version.

### Workflow and Documentation Updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L24-R33): Updated the GitHub NuGet registry authentication to use `${{ github.actor }}` and `${{ secrets.GITHUB_TOKEN }}` instead of `OWNER` and `${{ secrets.PACKAGE_TOKEN }}`. This change also includes storing the password in clear text.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R18): Added a new section with step-by-step instructions for publishing a new package version.

### Version Update:

* [`dotnet-package.csproj`](diffhunk://#diff-474faadfa188f4e6bbc2c429d8714741ec207511fac2d1a7df2bb2d7dbb0f8d5L12-R12): Bumped the package version from `1.0.0` to `1.0.3` for testing purposes.