### PR TITLE
workflows: add cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,45 @@
+name: Continuous Deployment
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build application
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Publish application
+        run: |
+          dotnet publish --configuration Release --output ./publish \
+            --no-restore
+
+      - name: Archive application
+        run: tar -czvf console-app.tar.gz -C ./publish .
+
+      - name: Upload to Azure Blob Storage
+        uses: azure/CLI@v1
+        env:
+          AZURE_STORAGE_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
+        with:
+          inlineScript: |
+            az storage blob upload --account-name actionsdemo \
+              --container-name console-app --name csharp-console-app \
+              --file console-app.tar.gz --auth-mode key \
+              --account-key $AZURE_STORAGE_ACCOUNT_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 
 on:
   push:


### PR DESCRIPTION
This pull request introduces a new continuous deployment workflow and updates the existing continuous integration workflow. The most important changes are as follows:

Continuous Deployment:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R1-R45): Added a new workflow for continuous deployment that triggers on pushes to the `main` branch and manual dispatch. This workflow includes steps for checking out code, setting up .NET, restoring dependencies, building the application, publishing the application, archiving the application, and uploading the archive to Azure Blob Storage.

Continuous Integration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R1): Renamed the workflow from "CI" to "Continuous Integration" for better clarity and consistency.