### PR TITLE
workflows: codeql updates and fixes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: "ubuntu-latest"
+    environment: "security"
 
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze C#
     runs-on: "ubuntu-latest"
     environment: "security"
 
@@ -16,13 +16,6 @@ jobs:
       security-events: write
       actions: read
       contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: csharp
-            build-mode: none
 
     steps:
       - name: Checkout repository
@@ -41,10 +34,12 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          languages: csharp
+          build-mode: manual
+
+      - run: dotnet build --configuration Release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Add the GitHub NuGet registry password
         run: |
           dotnet nuget update source "GitHub" --username ${{ github.actor }} \
-            --password ${{ secrets.TEST_TOKEN }} --store-password-in-clear-text
+            --password ${{ secrets.NUGET_TOKEN }} --store-password-in-clear-text
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration for CodeQL analysis:

* Since C# is the only language in this repo, removed the strategy matrix for languages and build modes, setting the language directly to "csharp" and the build mode to "manual".
* Updated the NuGet registry password reference from `TEST_TOKEN` to `NUGET_TOKEN` for clarity. Moved this secret into the `security` environment for enhanced security.
* Added a step to build the project using the `dotnet build --configuration Release` command to prevent 401s from CodeQL (which cannot handle private feeds when running in `build-mode:none` or `build-mode:autobuild`).